### PR TITLE
Accept arguments as an alternative to an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,13 @@
 'use strict';
 
+function isArray(object) {
+  return Object.prototype.toString.call(object) === '[object Array]'
+}
+
 module.exports = function(constants) {
+  if (! isArray(constants)) {
+    constants = arguments;
+  }
   var result = {};
   var i = -1;
   var len = constants.length;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function isArray(object) {
-  return Object.prototype.toString.call(object) === '[object Array]'
+  return Object.prototype.toString.call(object) === '[object Array]';
 }
 
 module.exports = function(constants) {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ function isArray(object) {
 }
 
 module.exports = function(constants) {
-  if (! isArray(constants)) {
+  if (!isArray(constants)) {
     constants = arguments;
   }
   var result = {};

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
-function isArray(object) {
+var isArray = Array.isArray || function(object) {
   return Object.prototype.toString.call(object) === '[object Array]';
-}
+};
 
 module.exports = function(constants) {
   if (!isArray(constants)) {

--- a/test/index.js
+++ b/test/index.js
@@ -19,7 +19,6 @@ test('non-empty array', function(t) {
 
 test('argument slice', function(t) {
   t.plan(1);
-
   t.looseEqual(konst('FOO', 'BAR', 'BAZ'), {
     FOO: 'FOO',
     BAR: 'BAR',

--- a/test/index.js
+++ b/test/index.js
@@ -16,3 +16,13 @@ test('non-empty array', function(t) {
     BAZ: 'BAZ'
   });
 });
+
+test('argument slice', function(t) {
+  t.plan(1);
+
+  t.looseEqual(konst('FOO', 'BAR', 'BAZ'), {
+    FOO: 'FOO',
+    BAR: 'BAR',
+    BAZ: 'BAZ'
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,27 @@
 'use strict';
 
 var test = require('tape');
-var konst = require('..');
+var konst;
+
+test('argument slice when Array.isArray does not exist', function(t) {
+  t.plan(1);
+
+  // Store the real isArray to reassign it back to Array later.
+  var isArray = Array.isArray;
+
+  // Make isArray null before requiring konst.
+  Array.isArray = null;
+  konst = require('..');
+  t.looseEqual(konst('FOO', 'BAR', 'BAZ'), {
+    FOO: 'FOO',
+    BAR: 'BAR',
+    BAZ: 'BAZ'
+  });
+
+  // Reassign isArray back to Array so that the rest of the tests can continue
+  // under the assumption that isArray exists.
+  Array.isArray = isArray;
+});
 
 test('empty array', function(t) {
   t.plan(1);
@@ -25,3 +45,4 @@ test('argument slice', function(t) {
     BAZ: 'BAZ'
   });
 });
+


### PR DESCRIPTION
This way you don't have to type brackets when calling the function.
